### PR TITLE
Rename formatter module

### DIFF
--- a/data_parser.py
+++ b/data_parser.py
@@ -52,7 +52,7 @@ def remove_quotes(string: str) -> str:
 
     if string[0] == "'" and string[-1] == "'":
         string = string[1:-1]
-    
+
     return string
 
 def remove_spaces(string: str) -> str:
@@ -73,4 +73,3 @@ def remove_spaces(string: str) -> str:
         string = string[:-1]
 
     return string
-

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ El archivo que se ejecuta y en el que se da la interacción con el
 usuario.
 """
 
-from formatter import format_path
+from data_parser import format_path
 from task_manager import task_manager
 from validator import is_option_valid, file_exists, is_body_valid
 
@@ -18,20 +18,16 @@ MENU = """
 
 print("Bienvenido")
 
-"""
-Inicia un ciclo while en True para que el programa se ejecute hasta que
-el usuario indique lo contrario.
-"""
+# Inicia un ciclo while en True para que el programa se ejecute hasta que
+# el usuario indique lo contrario.
 while True:
 
     print(MENU)
 
     option = input("\nIngresa el número correspondiente a la opción deseada: ")
 
-    """
-    Si se ingresa la opción 0, sale del ciclo while para terminar el 
-    programa.
-    """
+    # Si se ingresa la opción 0, sale del ciclo while para terminar el
+    # programa.
     if option == "0":
         break
 

--- a/task_manager.py
+++ b/task_manager.py
@@ -3,7 +3,7 @@ Contiene la función que se encarga manejar las tareas, es decir, de
 conectar la opción elegida con la función correspondiente.
 """
 
-from formatter import format_body, format_path
+from data_parser import format_body, format_path
 from file_handler import FileHandler
 from converter import count_nucleotides, dna_to_rna, rna_to_protein
 
@@ -35,5 +35,5 @@ def task_manager(option, path_to_file):
     elif option == "3":
         converted_body = rna_to_protein(body)
         suffix = "to_protein"
-    
+
     file_handler.write_file(converted_body, suffix)

--- a/validator.py
+++ b/validator.py
@@ -4,10 +4,10 @@ Contiene funciones necesarias para validación.
 
 from pathlib import Path
 from file_handler import FileHandler
-from formatter import format_body, format_path
+from data_parser import format_body, format_path
 
 
-def is_option_valid(option: str) -> bool: 
+def is_option_valid(option: str) -> bool:
     """
     Evalúa si la opción se encuentra en el menú.
 
@@ -18,9 +18,9 @@ def is_option_valid(option: str) -> bool:
         True si la opción está en el menú, False si no lo está.
     """
 
-    is_option_valid = option in "0123"
+    option_valid = option in "0123"
 
-    return is_option_valid
+    return option_valid
 
 
 def file_exists(path_to_file: str) -> bool:
@@ -35,9 +35,9 @@ def file_exists(path_to_file: str) -> bool:
     """
 
     path_to_file = Path(path_to_file)
-    file_exists = path_to_file.is_file()
+    exists = path_to_file.is_file()
 
-    return file_exists
+    return exists
 
 
 def is_body_valid(path_to_file: str) -> bool:
@@ -61,9 +61,9 @@ def is_body_valid(path_to_file: str) -> bool:
     for nucleotide in body:
 
         if nucleotide in "AGCTU":
-            is_body_valid = True
+            body_valid = True
         else:
-            is_body_valid = False
+            body_valid = False
             break
 
-    return is_body_valid
+    return body_valid


### PR DESCRIPTION
The purpose of this commit is to:
- Rename `formatter` module to `data_parse` to avoid confusion with formatter module in python standard library.
- Remove trailing and leading white spaces.
- Change the format of multiline comments from `"""` to `#` to avoid being confused with Docstrings.
- Rename those variables where their name was the same to the method.